### PR TITLE
Adapted to use PL/Java 1.6.0 annotations

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,10 +9,9 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<release>9</release>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -38,7 +37,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-api</artifactId>
-			<version>1.5.1</version>
+			<version>1.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-api</artifactId>
-			<version>1.5.0</version>
+			<version>1.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,6 +36,11 @@
 	</build>
 	<dependencies>
 		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>pljava-api</artifactId>
+			<version>1.5.0</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.10</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,6 +22,12 @@
 					<archive>
 						<manifestSections>
 							<manifestSection>
+								<name>pljava.ddr</name> <!-- filename -->
+								<manifestEntries>
+									<SQLJDeploymentDescriptor>TRUE</SQLJDeploymentDescriptor>
+								</manifestEntries>
+							</manifestSection>
+							<manifestSection>
 								<name>postgresql-udt.ddr</name> <!-- filename -->
 								<manifestEntries>
 									<SQLJDeploymentDescriptor>TRUE</SQLJDeploymentDescriptor>

--- a/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
@@ -75,6 +75,14 @@ public class ComplexUDT implements SQLData {
     }
 
     /**
+     * No-arg constructor. An SQLData implementation needs one, because
+     * readSQL is an instance method; before the runtime can invoke it when
+     * initializing a new instance, it first has to be able to <em>make</em>
+     * the new instance.
+     */
+    public ComplexUDT() { }
+
+    /**
      * Constructor taking only real value.
      * 
      * @param value

--- a/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
@@ -29,6 +29,12 @@ import java.sql.SQLInput;
 import java.sql.SQLOutput;
 import java.util.ResourceBundle;
 
+import org.postgresql.pljava.annotation.BaseUDT;
+import org.postgresql.pljava.annotation.Function;
+import static
+    org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
+
 import com.invariantproperties.udt.Complex;
 
 /**
@@ -40,6 +46,11 @@ import com.invariantproperties.udt.Complex;
  * 
  * @author bgiles@coyotesong.com
  */
+@BaseUDT(
+    schema="invariantproperties", name="complex",
+    internalLength=16,
+    alignment=BaseUDT.Alignment.INT4 // can this be right? components are 8 wide
+)
 public class ComplexUDT implements SQLData {
     private static final ResourceBundle bundle = ResourceBundle
             .getBundle(ComplexUDT.class.getName());
@@ -50,6 +61,7 @@ public class ComplexUDT implements SQLData {
     /**
      * Parse input string.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT parse(String input, String typeName)
             throws SQLException {
         // TODO: verify recognized typename.
@@ -128,6 +140,7 @@ public class ComplexUDT implements SQLData {
     /**
      * Read object from SQLInput stream.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public void readSQL(SQLInput stream, String typeName) throws SQLException {
         double re = stream.readDouble();
         double im = stream.readDouble();
@@ -138,6 +151,7 @@ public class ComplexUDT implements SQLData {
     /**
      * Write object to SQLOutput stream.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public void writeSQL(SQLOutput stream) throws SQLException {
         stream.writeDouble(value.Re());
         stream.writeDouble(value.Im());
@@ -181,10 +195,15 @@ public class ComplexUDT implements SQLData {
      * never be null, of course, but it might wrap an uninitialized value.
      * Therefore this method breaks the standard java contract and follows
      * the SQL contract.
+     *<p>
+     * It's all moot though, because the function is annotated RETURNS_NULL
+     * on null input, which means the PostgreSQL optimizer will <em>not even
+     * call it</em> on a null {@code invariantproperties.rational} value.
      * 
      * @see java.lang.Object#toString()
      */
     @Override
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public String toString() {
         return (value == null) ? null : value.toString();
     }
@@ -196,6 +215,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_string_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(String input) throws SQLException {
         if (input == null) {
             return null;
@@ -210,6 +231,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_double_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(double value) throws SQLException {
         return new ComplexUDT(value);
     }
@@ -221,6 +244,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_double_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(Double value) throws SQLException {
         return new ComplexUDT(value);
     }
@@ -233,6 +258,9 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        name="complex_bigdecimal_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(BigDecimal value) throws SQLException {
         return new ComplexUDT(value.doubleValue());
     }
@@ -244,6 +272,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_int_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(int value) throws SQLException {
         return new ComplexUDT(value);
     }
@@ -255,6 +285,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_long_as_complex",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT newInstance(long value) throws SQLException {
         return new ComplexUDT(value);
     }
@@ -266,6 +298,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_negate",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT negate(ComplexUDT p) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;
@@ -281,6 +315,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, ComplexUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -298,6 +334,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, int q) throws SQLException {
         return add(p, (double) q);
     }
@@ -310,6 +348,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, long q) throws SQLException {
         return add(p, (double) q);
     }
@@ -322,6 +362,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, float q) throws SQLException {
         return add(p, (double) q);
     }
@@ -334,6 +376,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, double q) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;
@@ -349,6 +393,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(ComplexUDT p, BigDecimal q)
             throws SQLException {
         return add(p, q.doubleValue());
@@ -362,6 +408,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(int q, ComplexUDT p) throws SQLException {
         return add(p, (double) q);
     }
@@ -374,6 +422,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(long q, ComplexUDT p) throws SQLException {
         return add(p, (double) q);
     }
@@ -386,6 +436,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(float q, ComplexUDT p) throws SQLException {
         return add(p, (double) q);
     }
@@ -398,6 +450,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(double q, ComplexUDT p) throws SQLException {
         return add(p, q);
     }
@@ -410,6 +464,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT add(BigDecimal q, ComplexUDT p)
             throws SQLException {
         return add(p, q.doubleValue());
@@ -423,6 +479,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_subtract",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT subtract(ComplexUDT p, ComplexUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -440,6 +498,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, ComplexUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -457,6 +517,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, int q) throws SQLException {
         return multiply(p, (double) q);
     }
@@ -469,6 +531,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, long q) throws SQLException {
         return multiply(p, (double) q);
     }
@@ -481,6 +545,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, float q)
             throws SQLException {
         return multiply(p, (double) q);
@@ -494,6 +560,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, double q)
             throws SQLException {
         if ((p == null) || (p.value == null)) {
@@ -510,6 +578,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(ComplexUDT p, BigDecimal q)
             throws SQLException {
         return multiply(p, q.doubleValue());
@@ -523,6 +593,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(int q, ComplexUDT p) throws SQLException {
         return multiply(p, (double) q);
     }
@@ -535,6 +607,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(long q, ComplexUDT p) throws SQLException {
         return multiply(p, (double) q);
     }
@@ -547,6 +621,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(float q, ComplexUDT p)
             throws SQLException {
         return multiply(p, (double) q);
@@ -560,6 +636,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(double q, ComplexUDT p)
             throws SQLException {
         return multiply(p, (double) q);
@@ -573,6 +651,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="complex_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT multiply(BigDecimal q, ComplexUDT p)
             throws SQLException {
         return multiply(p, q.doubleValue());
@@ -585,6 +665,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT abs(ComplexUDT p) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;
@@ -599,6 +681,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static ComplexUDT conjugate(ComplexUDT p) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;
@@ -613,6 +697,8 @@ public class ComplexUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static Double magnitude(ComplexUDT p) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;

--- a/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
@@ -246,19 +246,6 @@ public class ComplexUDT implements SQLData {
     }
 
     /**
-     * Static methods that will be published as user-defined function.
-     * 
-     * @param value
-     * @return
-     * @throws SQLException
-     */
-    @Function(schema="invariantproperties", name="complex_double_as_complex",
-        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-    public static ComplexUDT newInstance(Double value) throws SQLException {
-        return new ComplexUDT(value);
-    }
-
-    /**
      * Static methods that will be published as user-defined function. This may
      * result in the loss of significant digits.
      * 

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -30,6 +30,7 @@ import java.util.ResourceBundle;
 
 import org.postgresql.pljava.annotation.BaseUDT;
 import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
 import static
     org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
 import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
@@ -50,6 +51,22 @@ import com.invariantproperties.udt.Rational;
     schema="invariantproperties", name="rational",
     internalLength=16,
     alignment=BaseUDT.Alignment.INT4 // can this be right? components are 8 wide
+)
+@SQLAction(requires={"rationalmin", "rationalmax"},
+    install={
+        "CREATE AGGREGATE min(invariantproperties.rational) (" +
+        "sfunc = invariantproperties.min," +
+        "stype = invariantproperties.rational" +
+        ")",
+        "CREATE AGGREGATE max(invariantproperties.rational) (" +
+        "sfunc = invariantproperties.max," +
+        "stype = invariantproperties.rational" +
+        ")"
+    },
+    remove={
+        "DROP AGGREGATE max(invariantproperties.rational)",
+        "DROP AGGREGATE min(invariantproperties.rational)"
+    }
 )
 public class RationalUDT implements SQLData {
     private static final ResourceBundle bundle = ResourceBundle
@@ -457,6 +474,7 @@ public class RationalUDT implements SQLData {
      * @throws SQLException
      */
     @Function(schema="invariantproperties",
+        provides="rationalmin",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT min(RationalUDT p, RationalUDT q) {
         if ((p == null) || (p.value == null) || (q == null)
@@ -475,6 +493,7 @@ public class RationalUDT implements SQLData {
      * @throws SQLException
      */
     @Function(schema="invariantproperties",
+        provides="rationalmax",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT max(RationalUDT p, RationalUDT q) {
         if ((p == null) || (p.value == null) || (q == null)

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -31,6 +31,7 @@ import java.util.ResourceBundle;
 import org.postgresql.pljava.annotation.BaseUDT;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
 import static
     org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
 import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
@@ -52,22 +53,46 @@ import com.invariantproperties.udt.Rational;
     internalLength=16,
     alignment=BaseUDT.Alignment.INT4 // can this be right? components are 8 wide
 )
-@SQLAction(requires={"rationalmin", "rationalmax"},
-    install={
-        "CREATE AGGREGATE min(invariantproperties.rational) (" +
-        "sfunc = invariantproperties.min," +
-        "stype = invariantproperties.rational" +
-        ")",
-        "CREATE AGGREGATE max(invariantproperties.rational) (" +
-        "sfunc = invariantproperties.max," +
-        "stype = invariantproperties.rational" +
-        ")"
-    },
-    remove={
-        "DROP AGGREGATE max(invariantproperties.rational)",
-        "DROP AGGREGATE min(invariantproperties.rational)"
-    }
-)
+@SQLActions({
+    @SQLAction(requires={"rationalmin", "rationalmax"},
+        install={
+            "CREATE AGGREGATE min(invariantproperties.rational) (" +
+            "sfunc = invariantproperties.min," +
+            "stype = invariantproperties.rational" +
+            ")",
+            "CREATE AGGREGATE max(invariantproperties.rational) (" +
+            "sfunc = invariantproperties.max," +
+            "stype = invariantproperties.rational" +
+            ")"
+        },
+        remove={
+            "DROP AGGREGATE max(invariantproperties.rational)",
+            "DROP AGGREGATE min(invariantproperties.rational)"
+        }
+    ),
+    @SQLAction(
+        requires={"rationalfromstring", "rationalfromint", "rationalfromlong"},
+        install={
+            "CREATE CAST (varchar AS invariantproperties.rational) " +
+            "WITH FUNCTION " +
+	    "invariantproperties.rational_string_as_rational(varchar)" +
+            "AS ASSIGNMENT",
+
+            "CREATE CAST (int4 AS invariantproperties.rational) " +
+            "WITH FUNCTION invariantproperties.rational_int_as_rational(int4)" +
+            "AS ASSIGNMENT",
+
+            "CREATE CAST (int8 AS invariantproperties.rational) " +
+            "WITH FUNCTION invariantproperties.rational_long_as_rational(int8)"+
+            "AS ASSIGNMENT"
+        },
+        remove={
+	    "DROP CAST (int8 AS invariantproperties.rational)",
+	    "DROP CAST (int4 AS invariantproperties.rational)",
+	    "DROP CAST (varchar AS invariantproperties.rational)"
+        }
+    )
+})
 public class RationalUDT implements SQLData {
     private static final ResourceBundle bundle = ResourceBundle
             .getBundle(ComplexUDT.class.getName());
@@ -416,6 +441,7 @@ public class RationalUDT implements SQLData {
      * @throws SQLException
      */
     @Function(schema="invariantproperties", name="rational_string_as_rational",
+        provides="rationalfromstring",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(String input) throws SQLException {
         if (input == null) {
@@ -432,6 +458,7 @@ public class RationalUDT implements SQLData {
      * @throws SQLException
      */
     @Function(schema="invariantproperties", name="rational_int_as_rational",
+        provides="rationalfromint",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(int value) throws SQLException {
         return new RationalUDT(value);
@@ -445,6 +472,7 @@ public class RationalUDT implements SQLData {
      * @throws SQLException
      */
     @Function(schema="invariantproperties", name="rational_long_as_rational",
+        provides="rationalfromlong",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(long value) throws SQLException {
         return new RationalUDT(value);

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -28,6 +28,12 @@ import java.sql.SQLInput;
 import java.sql.SQLOutput;
 import java.util.ResourceBundle;
 
+import org.postgresql.pljava.annotation.BaseUDT;
+import org.postgresql.pljava.annotation.Function;
+import static
+    org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
+
 import com.invariantproperties.udt.Rational;
 
 /**
@@ -39,6 +45,12 @@ import com.invariantproperties.udt.Rational;
  * 
  * @author bgiles@coyotesong.com
  */
+
+@BaseUDT(
+    schema="invariantproperties", name="rational",
+    internalLength=16,
+    alignment=BaseUDT.Alignment.INT4 // can this be right? components are 8 wide
+)
 public class RationalUDT implements SQLData {
     private static final ResourceBundle bundle = ResourceBundle
             .getBundle(ComplexUDT.class.getName());
@@ -50,6 +62,7 @@ public class RationalUDT implements SQLData {
     /**
      * Parse input string.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT parse(String input, String typeName)
             throws SQLException {
         // TODO: verify recognized typename.
@@ -127,6 +140,7 @@ public class RationalUDT implements SQLData {
     /**
      * Read object from SQLInput stream.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public void readSQL(SQLInput stream, String typeName) throws SQLException {
         long n = stream.readLong();
         long d = stream.readLong();
@@ -137,6 +151,7 @@ public class RationalUDT implements SQLData {
     /**
      * Write object to SQLOutput stream.
      */
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public void writeSQL(SQLOutput stream) throws SQLException {
         stream.writeLong(value.getNumerator());
         stream.writeLong(value.getDenominator());
@@ -180,10 +195,15 @@ public class RationalUDT implements SQLData {
      * never be null, of course, but it might wrap an uninitialized value.
      * Therefore this method breaks the standard java contract and follows
      * the SQL contract.
+     *<p>
+     * It's all moot though, because the function is annotated RETURNS_NULL
+     * on null input, which means the PostgreSQL optimizer will <em>not even
+     * call it</em> on a null {@code invariantproperties.rational} value.
      * 
      * @see java.lang.Object#toString()
      */
     @Override
+    @Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public String toString() {
         return (value == null) ? null : value.toString();
     }
@@ -195,6 +215,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_cmp",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static int compare(RationalUDT p, RationalUDT q) {
         if ((p == null) || (p.value == null) || (q == null)
                 || (q.value == null)) {
@@ -210,6 +232,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_lt",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean lessThan(RationalUDT p, RationalUDT q) {
         return compare(p, q) < 0;
     }
@@ -221,6 +245,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_le",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean lessThanOrEquals(RationalUDT p, RationalUDT q) {
         return compare(p, q) <= 0;
     }
@@ -232,6 +258,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_eq",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean equals(RationalUDT p, RationalUDT q) {
         return compare(p, q) == 0;
     }
@@ -243,6 +271,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_ne",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean notEquals(RationalUDT p, RationalUDT q) {
         return !equals(p, q);
     }
@@ -254,6 +284,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_ge",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean greaterThanOrEquals(RationalUDT p, RationalUDT q) {
         return lessThanOrEquals(q, p);
     }
@@ -265,6 +297,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_gt",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean greaterThan(RationalUDT p, RationalUDT q) {
         return lessThan(q, p);
     }
@@ -276,6 +310,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_lt",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean lessThan(RationalUDT p, double q) {
         if ((p == null) || (p.value == null)) {
             return false;
@@ -290,6 +326,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_le",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean lessThanOrEquals(RationalUDT p, double q) {
         if ((p == null) || (p.value == null)) {
             return false;
@@ -304,6 +342,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_eq",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean equals(RationalUDT p, double q) {
         if ((p == null) || (p.value == null)) {
             return false;
@@ -318,6 +358,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_ge",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean greaterThanOrEquals(RationalUDT p, double q) {
         if ((p == null) || (p.value == null)) {
             return true;
@@ -332,6 +374,8 @@ public class RationalUDT implements SQLData {
      * @param q
      * @return
      */
+    @Function(schema="invariantproperties", name="rational_gt",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static boolean greaterThan(RationalUDT p, double q) {
         if ((p == null) || (p.value == null)) {
             return true;
@@ -346,6 +390,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_string_as_rational",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(String input) throws SQLException {
         if (input == null) {
             return null;
@@ -360,6 +406,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_int_as_rational",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(int value) throws SQLException {
         return new RationalUDT(value);
     }
@@ -371,6 +419,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_int_as_rational",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(Integer value) throws SQLException {
         if (value == null) {
             return null;
@@ -385,6 +435,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_long_as_rational",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(long value) throws SQLException {
         return new RationalUDT(value);
     }
@@ -396,6 +448,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_long_as_rational",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(Long value) throws SQLException {
         if (value == null) {
             return null;
@@ -426,6 +480,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT min(RationalUDT p, RationalUDT q) {
         if ((p == null) || (p.value == null) || (q == null)
                 || (q.value == null)) {
@@ -442,6 +498,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT max(RationalUDT p, RationalUDT q) {
         if ((p == null) || (p.value == null) || (q == null)
                 || (q.value == null)) {
@@ -457,6 +515,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_negate",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT negate(RationalUDT p) throws SQLException {
         if ((p == null) || (p.value == null)) {
             return null;
@@ -472,6 +532,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_add",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT add(RationalUDT p, RationalUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -489,6 +551,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_subtract",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT subtract(RationalUDT p, RationalUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -506,6 +570,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_multiply",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT multiply(RationalUDT p, RationalUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)
@@ -523,6 +589,8 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
+    @Function(schema="invariantproperties", name="rational_divide",
+        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT divide(RationalUDT p, RationalUDT q)
             throws SQLException {
         if ((p == null) || (p.value == null) || (q == null)

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -427,42 +427,10 @@ public class RationalUDT implements SQLData {
      * @return
      * @throws SQLException
      */
-    @Function(schema="invariantproperties", name="rational_int_as_rational",
-        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-    public static RationalUDT newInstance(Integer value) throws SQLException {
-        if (value == null) {
-            return null;
-        }
-        return new RationalUDT(value.longValue());
-    }
-
-    /**
-     * Static methods that will be published as user-defined function.
-     * 
-     * @param value
-     * @return
-     * @throws SQLException
-     */
     @Function(schema="invariantproperties", name="rational_long_as_rational",
         effects=IMMUTABLE, onNullInput=RETURNS_NULL)
     public static RationalUDT newInstance(long value) throws SQLException {
         return new RationalUDT(value);
-    }
-
-    /**
-     * Static methods that will be published as user-defined function.
-     * 
-     * @param value
-     * @return
-     * @throws SQLException
-     */
-    @Function(schema="invariantproperties", name="rational_long_as_rational",
-        effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-    public static RationalUDT newInstance(Long value) throws SQLException {
-        if (value == null) {
-            return null;
-        }
-        return new RationalUDT(value.longValue());
     }
 
     /**

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -76,6 +76,14 @@ public class RationalUDT implements SQLData {
     }
 
     /**
+     * No-arg constructor. An SQLData implementation needs one, because
+     * readSQL is an instance method; before the runtime can invoke it when
+     * initializing a new instance, it first has to be able to <em>make</em>
+     * the new instance.
+     */
+    public RationalUDT() { }
+
+    /**
      * Constructor taking only numerator.
      * 
      * @param numerator

--- a/java/src/main/resources/postgresql-udt.ddr
+++ b/java/src/main/resources/postgresql-udt.ddr
@@ -125,18 +125,6 @@ SQLActions[] = {
         OPERATOR        4       >= ,
         OPERATOR        5       > ,
         FUNCTION        1       invariantproperties.rational_cmp(invariantproperties.rational, invariantproperties.rational);
-
-    CREATE CAST (varchar AS invariantproperties.rational)
-      WITH FUNCTION invariantproperties.rational_string_as_rational(varchar)
-      AS ASSIGNMENT;
-
-    CREATE CAST (int4 AS invariantproperties.rational)
-      WITH FUNCTION invariantproperties.rational_int_as_rational(int4)
-      AS ASSIGNMENT;
-
-    CREATE CAST (int8 AS invariantproperties.rational)
-      WITH FUNCTION invariantproperties.rational_long_as_rational(int8)
-      AS ASSIGNMENT;
     
     /* ------------------------------------------------------------------------------- */
       

--- a/java/src/main/resources/postgresql-udt.ddr
+++ b/java/src/main/resources/postgresql-udt.ddr
@@ -1,66 +1,16 @@
 SQLActions[] = {
   "BEGIN INSTALL
-    CREATE TYPE invariantproperties.rational;
-
-    /* The scalar input function */
-    CREATE FUNCTION invariantproperties.rational_in(cstring)
-      RETURNS invariantproperties.rational
-      AS 'UDT[com.invariantproperties.udt.sql.RationalUDT] input'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar output function */
-    CREATE FUNCTION invariantproperties.rational_out(invariantproperties.rational)
-      RETURNS cstring
-      AS 'UDT[com.invariantproperties.udt.sql.RationalUDT] output'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar receive function */
-    CREATE FUNCTION invariantproperties.rational_recv(internal)
-      RETURNS invariantproperties.rational
-      AS 'UDT[com.invariantproperties.udt.sql.RationalUDT] receive'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar send function */
-    CREATE FUNCTION invariantproperties.rational_send(invariantproperties.rational)
-      RETURNS bytea
-      AS 'UDT[com.invariantproperties.udt.sql.RationalUDT] send'
-      LANGUAGE java IMMUTABLE STRICT;
-        
-    CREATE TYPE invariantproperties.rational (
-      internallength = 16,
-      input = invariantproperties.rational_in,
-      output = invariantproperties.rational_out,
-      receive = invariantproperties.rational_recv,
-      send = invariantproperties.rational_send,
-      alignment = int);
-      
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.numerator(invariantproperties.rational) RETURNS int8
           AS 'com.invariantproperties.udt.sql.RationalUDT.numerator'
           LANGUAGE JAVA IMMUTABLE STRICT;
+      */
       
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.denominator(invariantproperties.rational) RETURNS int8
           AS 'com.invariantproperties.udt.sql.RationalUDT.denominator'
           LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_negate(invariantproperties.rational) RETURNS invariantproperties.rational
-          AS 'com.invariantproperties.udt.sql.RationalUDT.negate'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_add(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-          AS 'com.invariantproperties.udt.sql.RationalUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_subtract(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-          AS 'com.invariantproperties.udt.sql.RationalUDT.subtract'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.rational_multiply(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-          AS 'com.invariantproperties.udt.sql.RationalUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.rational_divide(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-          AS 'com.invariantproperties.udt.sql.RationalUDT.divide'
-          LANGUAGE JAVA IMMUTABLE STRICT;
+      */
 
       CREATE OPERATOR - (
          rightarg = invariantproperties.rational, procedure = invariantproperties.rational_negate
@@ -84,58 +34,12 @@ SQLActions[] = {
          leftarg = invariantproperties.rational, rightarg = invariantproperties.rational, procedure = invariantproperties.rational_divide
       );
          
-      
-      CREATE FUNCTION invariantproperties.rational_lt(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.lessThan'
-          LANGUAGE JAVA IMMUTABLE STRICT;
 
-      CREATE FUNCTION invariantproperties.rational_le(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.lessThanOrEquals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_eq(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.equals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_ne(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.notEquals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-      
-      CREATE FUNCTION invariantproperties.rational_ge(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.greaterThanOrEquals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-      
-      CREATE FUNCTION invariantproperties.rational_gt(invariantproperties.rational, invariantproperties.rational) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.greaterThan'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_cmp(invariantproperties.rational, invariantproperties.rational) RETURNS int
-          AS 'com.invariantproperties.udt.sql.RationalUDT.compare'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_lt(invariantproperties.rational, float8) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.lessThan'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_le(invariantproperties.rational, float8) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.lessThanOrEquals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_eq(invariantproperties.rational, float8) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.equals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.rational_ne(invariantproperties.rational, float8) RETURNS bool
           AS 'com.invariantproperties.udt.sql.RationalUDT.notEquals'
           LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_ge(invariantproperties.rational, float8) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.greaterThanOrEquals'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.rational_gt(invariantproperties.rational, float8) RETURNS bool
-          AS 'com.invariantproperties.udt.sql.RationalUDT.greaterThan'
-          LANGUAGE JAVA IMMUTABLE STRICT;
+      */
 
       CREATE OPERATOR < (
          leftarg = invariantproperties.rational, rightarg = invariantproperties.rational, procedure = invariantproperties.rational_lt,
@@ -220,18 +124,6 @@ SQLActions[] = {
         OPERATOR        5       > ,
         FUNCTION        1       invariantproperties.rational_cmp(invariantproperties.rational, invariantproperties.rational);
 
-    CREATE FUNCTION invariantproperties.rational_string_as_rational(varchar) RETURNS invariantproperties.rational
-        AS 'com.invariantproperties.udt.sql.RationalUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.rational_int_as_rational(int4) RETURNS invariantproperties.rational
-        AS 'com.invariantproperties.udt.sql.RationalUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.rational_long_as_rational(int8) RETURNS invariantproperties.rational
-        AS 'com.invariantproperties.udt.sql.RationalUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
     CREATE CAST (varchar AS invariantproperties.rational)
       WITH FUNCTION invariantproperties.rational_string_as_rational(varchar)
       AS ASSIGNMENT;
@@ -244,14 +136,6 @@ SQLActions[] = {
       WITH FUNCTION invariantproperties.rational_long_as_rational(int8)
       AS ASSIGNMENT;
 
-    CREATE FUNCTION invariantproperties.min(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-        AS 'com.invariantproperties.udt.sql.RationalUDT.min'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.max(invariantproperties.rational, invariantproperties.rational) RETURNS invariantproperties.rational
-        AS 'com.invariantproperties.udt.sql.RationalUDT.max'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
     CREATE AGGREGATE min(invariantproperties.rational) (
       sfunc = invariantproperties.min,
       stype = invariantproperties.rational
@@ -263,160 +147,30 @@ SQLActions[] = {
     );
     
     /* ------------------------------------------------------------------------------- */
-    
-    CREATE TYPE invariantproperties.complex;
-
-    /* The scalar input function */
-    CREATE FUNCTION invariantproperties.complex_in(cstring)
-      RETURNS invariantproperties.complex
-      AS 'UDT[com.invariantproperties.udt.sql.ComplexUDT] input'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar output function */
-    CREATE FUNCTION invariantproperties.complex_out(invariantproperties.complex)
-      RETURNS cstring
-      AS 'UDT[com.invariantproperties.udt.sql.ComplexUDT] output'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar receive function */
-    CREATE FUNCTION invariantproperties.complex_recv(internal)
-      RETURNS invariantproperties.complex
-      AS 'UDT[com.invariantproperties.udt.sql.ComplexUDT] receive'
-      LANGUAGE java IMMUTABLE STRICT;
- 
-    /* The scalar send function */
-    CREATE FUNCTION invariantproperties.complex_send(invariantproperties.complex)
-      RETURNS bytea
-      AS 'UDT[com.invariantproperties.udt.sql.ComplexUDT] send'
-      LANGUAGE java IMMUTABLE STRICT;
-        
-    CREATE TYPE invariantproperties.complex (
-      internallength = 16,
-      input = invariantproperties.complex_in,
-      output = invariantproperties.complex_out,
-      receive = invariantproperties.complex_recv,
-      send = invariantproperties.complex_send,
-      alignment = int);
       
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.re(invariantproperties.complex) RETURNS float8
           AS 'com.invariantproperties.udt.sql.ComplexUDT.numerator'
           LANGUAGE JAVA IMMUTABLE STRICT;
+      */
       
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.im(invariantproperties.complex) RETURNS float8
           AS 'com.invariantproperties.udt.sql.ComplexUDT.denominator'
           LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_negate(invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.negate'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, int4) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, int8) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, float4) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, float8) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(invariantproperties.complex, numeric) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(int4, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(int8, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(float4, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(float8, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_add(numeric, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.add'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-
-      CREATE FUNCTION invariantproperties.complex_subtract(invariantproperties.complex, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.subtract'
-          LANGUAGE JAVA IMMUTABLE STRICT;
+      */
           
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, int4) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, int8) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, float4) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, float8) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(invariantproperties.complex, numeric) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(int4, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(int8, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(float4, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(float8, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
-      CREATE FUNCTION invariantproperties.complex_multiply(numeric, invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.multiply'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-          
+      /* this has no implementation in the Java source
       CREATE FUNCTION invariantproperties.complex_divide(invariantproperties.complex, invariantproperties.complex) RETURNS invariantproperties.complex
           AS 'com.invariantproperties.udt.sql.ComplexUDT.divide'
           LANGUAGE JAVA IMMUTABLE STRICT;
+      */
          
+      /* this return type differs from what is in the Java source
       CREATE FUNCTION invariantproperties.abs(invariantproperties.complex) RETURNS float8
           AS 'com.invariantproperties.udt.sql.ComplexUDT.abs'
           LANGUAGE JAVA IMMUTABLE STRICT;
-         
-      CREATE FUNCTION invariantproperties.conjugate(invariantproperties.complex) RETURNS invariantproperties.complex
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.conjugate'
-          LANGUAGE JAVA IMMUTABLE STRICT;
-         
-      CREATE FUNCTION invariantproperties.magnitude(invariantproperties.complex) RETURNS float8
-          AS 'com.invariantproperties.udt.sql.ComplexUDT.magnitude'
-          LANGUAGE JAVA IMMUTABLE STRICT;
+      */
           
       CREATE OPERATOR - (
          rightarg = invariantproperties.complex, procedure = invariantproperties.complex_negate
@@ -539,26 +293,6 @@ SQLActions[] = {
       CREATE OPERATOR / (
          leftarg = invariantproperties.complex, rightarg = invariantproperties.complex, procedure = invariantproperties.complex_divide
       );
-
-    CREATE FUNCTION invariantproperties.complex_string_as_complex(varchar) RETURNS invariantproperties.complex
-        AS 'com.invariantproperties.udt.sql.ComplexUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.complex_double_as_complex(float8) RETURNS invariantproperties.complex
-        AS 'com.invariantproperties.udt.sql.ComplexUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.complex_bigdecimal_as_complex(numeric) RETURNS invariantproperties.complex
-        AS 'com.invariantproperties.udt.sql.ComplexUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.complex_int_as_complex(int4) RETURNS invariantproperties.complex
-        AS 'com.invariantproperties.udt.sql.ComplexUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
-
-    CREATE FUNCTION invariantproperties.complex_long_as_complex(int8) RETURNS invariantproperties.complex
-        AS 'com.invariantproperties.udt.sql.ComplexUDT.newInstance'
-        LANGUAGE JAVA IMMUTABLE STRICT;
 
     CREATE CAST (varchar AS invariantproperties.complex)
       WITH FUNCTION invariantproperties.complex_string_as_complex(varchar)

--- a/java/src/main/resources/postgresql-udt.ddr
+++ b/java/src/main/resources/postgresql-udt.ddr
@@ -137,16 +137,6 @@ SQLActions[] = {
     CREATE CAST (int8 AS invariantproperties.rational)
       WITH FUNCTION invariantproperties.rational_long_as_rational(int8)
       AS ASSIGNMENT;
-
-    CREATE AGGREGATE min(invariantproperties.rational) (
-      sfunc = invariantproperties.min,
-      stype = invariantproperties.rational
-    );
-
-    CREATE AGGREGATE max(invariantproperties.rational) (
-      sfunc = invariantproperties.max,
-      stype = invariantproperties.rational
-    );
     
     /* ------------------------------------------------------------------------------- */
       

--- a/java/src/main/resources/postgresql-udt.ddr
+++ b/java/src/main/resources/postgresql-udt.ddr
@@ -100,10 +100,12 @@ SQLActions[] = {
          commutator = == , negator = <> 
       );
 
+      /* this has no implementation in the Java source
       CREATE OPERATOR <> (
          leftarg = invariantproperties.rational, rightarg = float8, procedure = invariantproperties.rational_ne,
          commutator = <> , negator = == 
       );
+      */
 
       CREATE OPERATOR >= (
          leftarg = invariantproperties.rational, rightarg = float8, procedure = invariantproperties.rational_ge,
@@ -290,9 +292,11 @@ SQLActions[] = {
          commutator = * 
       );
 
+      /* this has no implementation in the Java source
       CREATE OPERATOR / (
          leftarg = invariantproperties.complex, rightarg = invariantproperties.complex, procedure = invariantproperties.complex_divide
       );
+      */
 
     CREATE CAST (varchar AS invariantproperties.complex)
       WITH FUNCTION invariantproperties.complex_string_as_complex(varchar)
@@ -315,9 +319,68 @@ SQLActions[] = {
       AS ASSIGNMENT;
 
    END INSTALL",
-   
-  "BEGIN REMOVE
-    DROP TYPE invariantproperties.complex cascade;
-    DROP TYPE invariantproperties.rational cascade;
-  END REMOVE"
+
+   "BEGIN REMOVE
+    DROP CAST (int8 AS invariantproperties.complex);
+    DROP CAST (int4 AS invariantproperties.complex);
+    DROP CAST (float8 AS invariantproperties.complex);
+    DROP CAST (numeric AS invariantproperties.complex);
+    DROP CAST (varchar AS invariantproperties.complex);
+    /* DROP OPERATOR / ( invariantproperties.complex, invariantproperties.complex ); */
+    DROP OPERATOR * ( numeric, invariantproperties.complex );
+    DROP OPERATOR * ( float8, invariantproperties.complex );
+    DROP OPERATOR * ( float4, invariantproperties.complex );
+    DROP OPERATOR * ( int8, invariantproperties.complex );
+    DROP OPERATOR * ( int4, invariantproperties.complex );
+    DROP OPERATOR * ( invariantproperties.complex, numeric );
+    DROP OPERATOR * ( invariantproperties.complex, float8 );
+    DROP OPERATOR * ( invariantproperties.complex, float4 );
+    DROP OPERATOR * ( invariantproperties.complex, int8 );
+    DROP OPERATOR * ( invariantproperties.complex, int4 );
+    DROP OPERATOR * ( invariantproperties.complex, invariantproperties.complex );
+    DROP OPERATOR - ( invariantproperties.complex, invariantproperties.complex );
+    DROP OPERATOR + ( numeric, invariantproperties.complex );
+    DROP OPERATOR + ( float8, invariantproperties.complex );
+    DROP OPERATOR + ( float4, invariantproperties.complex );
+    DROP OPERATOR + ( int8, invariantproperties.complex );
+    DROP OPERATOR + ( int4, invariantproperties.complex );
+    DROP OPERATOR + ( invariantproperties.complex, numeric );
+    DROP OPERATOR + ( invariantproperties.complex, float8 );
+    DROP OPERATOR + ( invariantproperties.complex, float4 );
+    DROP OPERATOR + ( invariantproperties.complex, int8 );
+    DROP OPERATOR + ( invariantproperties.complex, int4 );
+    DROP OPERATOR + ( invariantproperties.complex, invariantproperties.complex );
+    DROP OPERATOR - ( none, invariantproperties.complex );
+    /*
+    DROP FUNCTION invariantproperties.abs(invariantproperties.complex);
+    DROP FUNCTION invariantproperties.complex_divide(invariantproperties.complex, invariantproperties.complex);
+    DROP FUNCTION invariantproperties.im(invariantproperties.complex);
+    DROP FUNCTION invariantproperties.re(invariantproperties.complex);
+    */
+    DROP OPERATOR FAMILY rational_ops USING btree;
+    DROP OPERATOR > ( invariantproperties.rational, float8 );
+    DROP OPERATOR >= ( invariantproperties.rational, float8 );
+    /* DROP OPERATOR <> ( invariantproperties.rational, float8 ); */
+    DROP OPERATOR == ( invariantproperties.rational, float8 );
+    DROP OPERATOR = ( invariantproperties.rational, float8 );
+    DROP OPERATOR <= ( invariantproperties.rational, float8 );
+    DROP OPERATOR < ( invariantproperties.rational, float8 );
+    DROP OPERATOR > ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR >= ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR <> ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR == ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR = ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR <= ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR < ( invariantproperties.rational, invariantproperties.rational );
+    /* DROP FUNCTION invariantproperties.rational_ne(invariantproperties.rational, float8); */
+    DROP OPERATOR / ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR * ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR - ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR + ( invariantproperties.rational, invariantproperties.rational );
+    DROP OPERATOR - ( none, invariantproperties.rational );
+    /*
+    DROP FUNCTION invariantproperties.denominator(invariantproperties.rational);
+    DROP FUNCTION invariantproperties.numerator(invariantproperties.rational);
+    */
+   END REMOVE"
 }


### PR DESCRIPTION
Hi Bear,

Since your repo here gives one of the most complete available fully-worked examples of user-defined types in PL/Java, I thought that in celebration of the [PL/Java 1.6.0 release](https://github.com/tada/pljava/releases/tag/V1_6_0) I would send you a branch adapting the code to use the [annotation-driven SQL generation in 1.6.0](http://tada.github.io/pljava/pljava-api/apidocs/index.html?org/postgresql/pljava/annotation/package-summary.html) instead of writing all the deployment descriptor SQL by hand.

So here it is, as a sequence of commits showing a step-by-step approach to migrating the code (partially) to the annotation style, while removing the corresponding bits from the hand-maintained deployment descriptor file. It doesn't have to be an all-or-nothing conversion, both the generated and hand-crafted DDR files can coexist in the jar. To illustrate that, I did just a partial migration, enough to show how it's done, and left the rest alone.

This pull request (and this comment about it!) you will find nearly identical to my older pull request #2 (which I will now close), which illustrated the same exercise but for PL/Java 1.5.1. In 1.5.1, the SQL generator got smart enough to recognize references to the UDT being defined, so the old commit bcb5734, with its tedious additions of type annotations, went away then. Only with PL/Java 1.6.0 does the SQL generator get smart enough to also make commit d32f84e unnecessary, so in this branch, it goes away too, taking those tedious `provides`/`requires` with it.

One thing I regret to report about PL/Java 1.6.0 is that there (still!) is not support for making your package here be a PostgreSQL extension in its own right. You can (and do) package functionality together for PL/Java in the form of a jar file, with SQL deploy/undeploy commands built in, and in a way that's very much _like_ extensions, and gives you most of what extensions give you. But you can't yet have PL/Java treat your jar _as_ a PostgreSQL extension; that's a current limitation covered in the release notes and there's an open `pgsql-hackers` thread on how to solve it for a future release. You might have made it (seem to) work in pre-1.5.0 PL/Java, but not really reliably, and 1.5.0+ actually knows it can't and will say so if you try.

So, _for now_, the best story there is for packaging PL/Java functionality is, make a jar of it, with deployment descriptors, and install it with `sqlj.install_jar` and remove it with `sqlj.remove_jar`. That's enough for the ISO standard and, for now, it's what PL/Java supports.

PL/Java _itself_ installs as an extension in 1.5.0+, of course.