### PR TITLE
Force resource bundles to FORMAT_PROPERTIES

### DIFF
--- a/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/ComplexUDT.java
@@ -28,6 +28,8 @@ import java.sql.SQLException;
 import java.sql.SQLInput;
 import java.sql.SQLOutput;
 import java.util.ResourceBundle;
+import static java.util.ResourceBundle.Control.getControl;
+import static java.util.ResourceBundle.Control.FORMAT_PROPERTIES;
 
 import com.invariantproperties.udt.Complex;
 
@@ -41,8 +43,8 @@ import com.invariantproperties.udt.Complex;
  * @author bgiles@coyotesong.com
  */
 public class ComplexUDT implements SQLData {
-    private static final ResourceBundle bundle = ResourceBundle
-            .getBundle(ComplexUDT.class.getName());
+    private static final ResourceBundle bundle = ResourceBundle.getBundle(
+	ComplexUDT.class.getName(), getControl(FORMAT_PROPERTIES));
     private static final String TYPE_NAME = bundle.getString("typeName");
     private Complex value;
     private String typeName;

--- a/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
+++ b/java/src/main/java/com/invariantproperties/udt/sql/RationalUDT.java
@@ -27,6 +27,8 @@ import java.sql.SQLException;
 import java.sql.SQLInput;
 import java.sql.SQLOutput;
 import java.util.ResourceBundle;
+import static java.util.ResourceBundle.Control.getControl;
+import static java.util.ResourceBundle.Control.FORMAT_PROPERTIES;
 
 import com.invariantproperties.udt.Rational;
 
@@ -40,8 +42,8 @@ import com.invariantproperties.udt.Rational;
  * @author bgiles@coyotesong.com
  */
 public class RationalUDT implements SQLData {
-    private static final ResourceBundle bundle = ResourceBundle
-            .getBundle(ComplexUDT.class.getName());
+    private static final ResourceBundle bundle = ResourceBundle.getBundle(
+	RationalUDT.class.getName(), getControl(FORMAT_PROPERTIES));
     private static final String TYPE_NAME = bundle.getString("typeName");
     private static final int NULL_POSITION = 1;
     private Rational value;


### PR DESCRIPTION
There is a curious reason why these examples fail to load into PL/Java with exception-in-initializer errors.

Each one tries to load a `ResourceBundle`, and uses `Class.getName()` as the base name of the bundle. Indeed, the jar includes files with pathnames that exactly match the class files, only ending with `.properties` in place of `.class`.

The thing is, the `getBundle(basename)` that takes only a basename tries to find it in any of the formats in `ResourceBundle.Control.FORMAT_DEFAULT`, which lists `java.class` and `java.properties` in that order. So the first thing `getBundle` tries to do is look for a class with the exact name just obtained from `Class.getName()`! Sure enough, it finds one!

Of course the class it finds isn't a subclass of `ResourceBundle`, so that excitement dies down quickly with a `ClassCastException`.

I am not sure how this was even originally meant to work. Checking Java's API docs, the order of `FORMAT_DEFAULT` has been class first, then properties, at least as far back as Java 6.

Solved here in the laziest way, just by adding a `Control` argument to force `FORMAT_PROPERTIES`. However, that will lead to a future headache somewhere down the road: when a future PL/Java supports modular user code and these examples can be made into modules ... `ResourceBundle.Control` is not allowed in modular code. But that bridge can be crossed when it comes.

Another solution would be to give the property files names that simply don't exactly match the class names.

In passing, also fixed what appeared to be a copy-pasto: in each of the two classes, the class object `getName()` was called on was the one for `ComplexUDT`, even though there is a property file that goes with each class.